### PR TITLE
Enable dashboard visibility outside container

### DIFF
--- a/run.py
+++ b/run.py
@@ -33,12 +33,13 @@ def main():
         if 'redis_password' in os.environ:
             ray.init(
                 address=os.environ["ip_head"],
-                _redis_password=os.environ['redis_password']
+                _redis_password=os.environ['redis_password'],
+                dashboard_host='0.0.0.0'
             )
         else:
-            ray.init(address='auto')
+            ray.init(address='auto', dashboard_host='0.0.0.0')
     except ConnectionError:
-        ray.init()
+        ray.init(dashboard_host='0.0.0.0')
     except PermissionError:
         print('Failed to create a temporary directory for ray')
         raise


### PR DESCRIPTION
Allow the Ray dashboard to be visible outside the container

## Description
This PR enables web dashboard visibility from outside the docker container

## Example / Current workflow
Ray dashboard runs on 127.0.0.1 by default

## Bugfix / Desired workflow
Ray dashboard runs on all interfaces (0.0.0.0) in the container, making it visible outside the container

## Questions
N/A

## Relevant issues
N/A

## Checklist
- [ ] linted with flake8?
- [ ] (if appropriate) unit tests added?
- [x] **ready to go?**
